### PR TITLE
server,cmd: fix error handling

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -45,7 +46,7 @@ var runtimeVersionCommand = cli.Command{
 		// Set up a connection to the server.
 		conn, err := grpc.Dial(address, grpc.WithInsecure())
 		if err != nil {
-			log.Fatalf("Failed to connect: %v", err)
+			return fmt.Errorf("Failed to connect: %v", err)
 		}
 		defer conn.Close()
 		client := pb.NewRuntimeServiceClient(conn)
@@ -54,9 +55,8 @@ var runtimeVersionCommand = cli.Command{
 		version := "v1alpha1"
 		err = Version(client, version)
 		if err != nil {
-			log.Fatalf("Getting the runtime version failed: %v", err)
+			return fmt.Errorf("Getting the runtime version failed: %v", err)
 		}
-
 		return nil
 	},
 }

--- a/server/server.go
+++ b/server/server.go
@@ -17,14 +17,14 @@ func (s *Server) Version(ctx context.Context, req *pb.VersionRequest) (*pb.Versi
 
 	version, err := getGPRCVersion()
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	runtimeName := "runc"
 
 	runtimeVersion, err := execRuncVersion("runc", "-v")
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	runtimeApiVersion := "v1alpha1"


### PR DESCRIPTION
client and server were busted because we were returning `nil` when instead there was an error:

```
20:33:43 amurdaca at localhost in github.com/mrunalp/ocid ‹master*› ./ocid 
2016/07/19 20:33:47 grpc: Server failed to encode response proto: Marshal called with nil
```

```
20:32:53 amurdaca at localhost in github.com/mrunalp/ocid ‹master*› ./ocic runtimeversion
2016/07/19 20:33:00 transport: http2Client.notifyError got notified that the client transport was broken EOF.
2016/07/19 20:33:01 grpc: Conn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp [::1]:49999: getsockopt: connection refused"; Reconnecting to "localhost:49999"
2016/07/19 20:33:03 grpc: Conn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp [::1]:49999: getsockopt: connection refused"; Reconnecting to "localhost:49999"
2016/07/19 20:33:06 grpc: Conn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp [::1]:49999: getsockopt: connection refused"; Reconnecting to "localhost:49999"
2016/07/19 20:33:10 grpc: Conn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp [::1]:49999: getsockopt: connection refused"; Reconnecting to "localhost:49999"

```

Signed-off-by: Antonio Murdaca runcom@redhat.com
