### PR TITLE
Set server as subreaper

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"fmt"
+
 	"github.com/mrunalp/ocid/oci"
+	"github.com/mrunalp/ocid/utils"
 )
 
 const (
@@ -17,6 +20,12 @@ type Server struct {
 
 // New creates a new Server with options provided
 func New(runtimePath, sandboxDir, containerDir string) (*Server, error) {
+	// TODO: This will go away later when we have wrapper process or systemd acting as
+	// subreaper.
+	if err := utils.SetSubreaper(1); err != nil {
+		return nil, fmt.Errorf("failed to set server as subreaper: %v", err)
+	}
+
 	r, err := oci.New(runtimePath, containerDir)
 	if err != nil {
 		return nil, err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,7 +3,10 @@ package utils
 import (
 	"bytes"
 	"os/exec"
+	"syscall"
 )
+
+const PR_SET_CHILD_SUBREAPER = 36
 
 func ExecCmd(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
@@ -16,4 +19,18 @@ func ExecCmd(name string, args ...string) (string, error) {
 	}
 
 	return out.String(), nil
+}
+
+// SetSubreaper sets the value i as the subreaper setting for the calling process
+func SetSubreaper(i int) error {
+	return Prctl(PR_SET_CHILD_SUBREAPER, uintptr(i), 0, 0, 0)
+}
+
+// Prctl is a way to make the prctl linux syscall
+func Prctl(option int, arg2, arg3, arg4, arg5 uintptr) (err error) {
+	_, _, e1 := syscall.Syscall6(syscall.SYS_PRCTL, uintptr(option), arg2, arg3, arg4, arg5, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
 }


### PR DESCRIPTION
This is to start handling creation of containers. This will be reworked to use wrapper/systemd in the future.
@runcom @hmeng-19 PTAL
