### PR TITLE
Fix the err info of utils.ExecCmd

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
+	"strings"
 	"syscall"
 )
 
@@ -10,15 +12,17 @@ const PR_SET_CHILD_SUBREAPER = 36
 
 func ExecCmd(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
 	err := cmd.Run()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("`%v %v` failed: %v (%v)", name, strings.Join(args, " "), stderr.String(), err)
 	}
 
-	return out.String(), nil
+	return stdout.String(), nil
 }
 
 // SetSubreaper sets the value i as the subreaper setting for the calling process


### PR DESCRIPTION
This PR aims to add more info when an error happens during `utils.ExecCmd`. 

Signed-off-by: Haiyan Meng haiyanalady@gmail.com
