### PR TITLE
sandboxDir not needed in runtime

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -27,7 +27,6 @@ func New(runtimePath string, containerDir string) (*Runtime, error) {
 type Runtime struct {
 	name         string
 	path         string
-	sandboxDir   string
 	containerDir string
 }
 


### PR DESCRIPTION
Just learning the structure for the network stuff, noticed a minor slip. sanboxDir is already present with the server.
